### PR TITLE
DOC: Fix README CircleCI badge target.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,7 @@ Morphological Contour Interpolation
 ===================================
 
 .. image:: https://circleci.com/gh/KitwareMedical/ITKMorphologicalContourInterpolation.svg?style=svg
-  :target:
-  https://circleci.com/gh/KitwareMedical/ITKMorphologicalContourInterpolation
+  :target: https://circleci.com/gh/KitwareMedical/ITKMorphologicalContourInterpolation
 
 An `ITK <http://itk.org>`_-based implementation of morphological contour
 interpolation off the paper:


### PR DESCRIPTION
Addresses error:

README.rst:4: (ERROR/3) Error in "image" directive:
invalid option block.

.. image:: https://circleci.com/gh/KitwareMedical/ITKMorphologicalContourInterpolation.svg?style=svg
  :target:
  https://circleci.com/gh/KitwareMedical/ITKMorphologicalContourInterpolation

And rendering on GitHub.