### PR TITLE
Module docs say that testing requires RLEImage

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -1,5 +1,6 @@
 set(DOCUMENTATION "The modules provides filters to do interpolation
-of manually segmented anatomical contours.")
+of manually segmented anatomical contours.
+Enabling testing requires RLEImage module to be enabled.")
 
 itk_module(MorphologicalContourInterpolation
   DEPENDS


### PR DESCRIPTION
Stopgap measure until cross-dependency between remote modules gets better handling.