### PR TITLE
COMP: Specify std:: prefix for pow

### DIFF
--- a/include/itkMorphologicalContourInterpolator.hxx
+++ b/include/itkMorphologicalContourInterpolator.hxx
@@ -1279,7 +1279,7 @@ MorphologicalContourInterpolator< TImage >
   typename SliceType::IndexType bestIndex;
   IdentifierType iter = 0;
   IdentifierType minIter = std::min( m_MinAlignIters, searchRegion.GetNumberOfPixels() );
-  IdentifierType maxIter = std::max( m_MaxAlignIters, (IdentifierType)sqrt( searchRegion.GetNumberOfPixels() ) );
+  IdentifierType maxIter = std::max( m_MaxAlignIters, static_cast<IdentifierType>(std::sqrt( static_cast< double >(searchRegion.GetNumberOfPixels()) ) ));
 
   while ( !uncomputed.empty() )
     {

--- a/include/itkMorphologicalContourInterpolator.hxx
+++ b/include/itkMorphologicalContourInterpolator.hxx
@@ -146,8 +146,8 @@ MorphologicalContourInterpolator< TImage >
   m_UseDistanceTransform( true ),
   m_UseBallStructuringElement( false ),
   m_UseCustomSlicePositions( false ),
-  m_MinAlignIters( pow( 2, TImage::ImageDimension ) ), // smaller of this and pixel count of the search image
-  m_MaxAlignIters( pow( 6, TImage::ImageDimension ) ), // bigger of this and root of pixel count of the search image
+  m_MinAlignIters( std::pow( 2., static_cast< int >(TImage::ImageDimension) ) ), // smaller of this and pixel count of the search image
+  m_MaxAlignIters( std::pow( 6., static_cast< int >(TImage::ImageDimension) ) ), // bigger of this and root of pixel count of the search image
   m_ThreadCount( MultiThreader::GetGlobalDefaultNumberOfThreads() ),
   m_LabeledSlices( TImage::ImageDimension ) // initialize with empty sets
 {

--- a/include/itkMorphologicalContourInterpolator.hxx
+++ b/include/itkMorphologicalContourInterpolator.hxx
@@ -566,9 +566,9 @@ MorphologicalContourInterpolator< TImage >
   long long bestDiff = LLONG_MAX;
   for ( unsigned b = 0; b < maxSize; b++ )
     {
-    long long iS = std::abs( iTotal - iSum[b] + jSum[b] );
-    long long jS = std::abs( jTotal - jSum[b] + iSum[b] );
-    long long diff = std::abs( iS - jS );
+    long long iS = Math::abs( iTotal - iSum[b] + jSum[b] );
+    long long jS = Math::abs( jTotal - jSum[b] + iSum[b] );
+    long long diff = Math::abs( iS - jS );
     if ( diff < bestDiff )
       {
       bestDiff = diff;
@@ -859,7 +859,7 @@ MorphologicalContourInterpolator< TImage >
     } // iterator destroyed here
 
   // recurse if needed
-  if ( std::abs( i - j ) > 2 )
+  if ( Math::abs( i - j ) > 2 )
     {
     PixelList regionIDs;
     regionIDs.push_back( 1 );
@@ -870,8 +870,8 @@ MorphologicalContourInterpolator< TImage >
       ( j > reqRegion.GetIndex( axis ) + IndexValueType( reqRegion.GetSize( axis ) ) ? +1 : 0 );
     int mReq = mid < reqRegion.GetIndex( axis ) ? -1 :
       ( mid > reqRegion.GetIndex( axis ) + IndexValueType( reqRegion.GetSize( axis ) ) ? +1 : 0 );
-    bool first = std::abs( i - mid ) > 1 && std::abs( iReq + mReq ) <= 1; // i-mid?
-    bool second = std::abs( j - mid ) > 1 && std::abs( jReq + mReq ) <= 1; // j-mid?
+    bool first = Math::abs( i - mid ) > 1 && Math::abs( iReq + mReq ) <= 1; // i-mid?
+    bool second = Math::abs( j - mid ) > 1 && Math::abs( jReq + mReq ) <= 1; // j-mid?
 
     if ( first )
       {
@@ -1589,7 +1589,7 @@ MorphologicalContourInterpolator< TImage >
           ( *next > reqRegion.GetIndex( axis ) + IndexValueType( reqRegion.GetSize( axis ) ) ? +1 : 0 );
 
         if ( *prev + 1 < *next // only if they are not adjacent slices
-             && std::abs(iReq + jReq) <= 1 ) // and not out of the requested region
+             && Math::abs(iReq + jReq) <= 1 ) // and not out of the requested region
         // unless they are on opposite ends
           {
           SegmentBetweenTwo< TImage > s;


### PR DESCRIPTION
To address:

/FdWrapping\Modules\MorphologicalContourInterpolation\CMakeFiles\MorphologicalContourInterpolationPython.dir\ -c Wrapping\Modules\MorphologicalContourInterpolation\itkMorphologicalContourInterpolatorPython.cpp
c:\projects\itkmorphologicalcontourinterpolation\include\itkMorphologicalContourInterpolator.hxx(149) : error C2668: 'pow' : ambiguous call to overloaded function