### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkMorphologicalContourInterpolator.h
+++ b/include/itkMorphologicalContourInterpolator.h
@@ -69,6 +69,8 @@ class MorphologicalContourInterpolator:
   friend class MorphologicalContourInterpolatorParallelInvoker;
 
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalContourInterpolator);
+
   /** Standard class type alias. */
   using Self = MorphologicalContourInterpolator;
   using Superclass = ImageToImageFilter< TImage, TImage >;
@@ -401,11 +403,6 @@ protected:
 
   using ConnectedComponentsType = ConnectedComponentImageFilter< BoolSliceType, SliceType >;
   typename ConnectedComponentsType::Pointer m_ConnectedComponents;
-
-private:
-  MorphologicalContourInterpolator( const Self & ) = delete;
-  void
-  operator=( const Self & ) = delete;
 };
 } // namespace itk
 


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.