### PR TITLE
ENH: Conform to the ITKModuleTemplate CI files.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,41 @@
 version: 2
 jobs:
   build-and-test:
-    working_directory: ~/ITKMorphologicalContourInterpolation-build
+    working_directory: /ITKMorphologicalContourInterpolation-build
     docker:
       - image: insighttoolkit/module-ci:latest
     steps:
       - checkout:
-          path: ~/ITKMorphologicalContourInterpolation
+          path: /ITKMorphologicalContourInterpolation
       - run:
-          name: Configure
+          name: Fetch CTest driver script
           command: |
-            cmake \
-              -G Ninja \
-              -DITK_DIR:PATH=/ITK-build \
-              -DBUILD_TESTING:BOOL=ON \
-              -DBUILDNAME:STRING=External-ITKMorphologicalContourInterpolation-${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM} \
-                ~/ITKMorphologicalContourInterpolation
+            curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/dashboard/itk_common.cmake -O
+      - run:
+          name: Configure CTest script
+          command: |
+            SHASNIP=$(echo $CIRCLE_SHA1 | cut -c1-7)
+            cat > dashboard.cmake << EOF
+            set(CTEST_SITE "CircleCI")
+            set(CTEST_BUILD_NAME "External-ITKMorphologicalContourInterpolation-${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}-${SHASNIP}")
+            set(CTEST_BUILD_CONFIGURATION "MinSizeRel")
+            set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+            set(CTEST_BUILD_FLAGS: "-j5")
+            set(CTEST_SOURCE_DIRECTORY /ITKMorphologicalContourInterpolation)
+            set(CTEST_BINARY_DIRECTORY /ITKMorphologicalContourInterpolation-build)
+            set(dashboard_model Experimental)
+            set(dashboard_no_clean 1)
+            set(dashboard_cache "
+            ITK_DIR:PATH=/ITK-build
+            BUILD_TESTING:BOOL=ON
+            ")
+            include(\${CTEST_SCRIPT_DIRECTORY}/itk_common.cmake)
+            EOF
       - run:
           name: Build and Test
           no_output_timeout: 1.0h
           command: |
-            ctest -j 2 -VV -D Experimental
+            ctest -j 2 -VV -S dashboard.cmake
   package:
     working_directory: ~/ITKMorphologicalContourInterpolation
     machine: true
@@ -29,7 +44,7 @@ jobs:
       - run:
           name: Fetch build script
           command: |
-            curl -L https://rawgit.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh -O
+            curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh -O
             chmod u+x dockcross-manylinux-download-cache-and-build-module-wheels.sh
       - run:
           name: Build Python packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ compiler:
 - gcc
 cache:
   directories:
-  - "$HOME/deps"
+    - "$HOME/Library/Caches/Homebrew"
 script:
-- curl -L https://rawgit.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/macpython-download-cache-and-build-module-wheels.sh -O
+- curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/macpython-download-cache-and-build-module-wheels.sh -O
 - chmod u+x macpython-download-cache-and-build-module-wheels.sh
 - ./macpython-download-cache-and-build-module-wheels.sh
 - tar -zcvf dist.tar.gz dist/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ version: "1.0.0.{build}"
 
 install:
 
-  - curl -L https://rawgit.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/windows-download-cache-and-build-module-wheels.ps1 -O
+  - curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/windows-download-cache-and-build-module-wheels.ps1 -O
   - ps: .\windows-download-cache-and-build-module-wheels.ps1
 
 build: off


### PR DESCRIPTION
- Cache the Homebrew packages for faster brew install.
- Use `transfer.sh` to upload macOS packages. `filebin.ca` is no longer
  reliable.
- Use CTest script for CircleCI build: enables uploading of the revision
  to CTest in the update field and more control over the CTest build
  configuration.