### PR TITLE
STYLE: Prefer error checked std::sto[id] over ato[if].

### DIFF
--- a/examples/mciExample.cxx
+++ b/examples/mciExample.cxx
@@ -28,7 +28,7 @@ int main(int argc, char * argv[])
     int smoothingRadius = 2;
     if (argc >= 4)
       {
-      smoothingRadius = atoi(argv[3]);
+      smoothingRadius = std::stoi(argv[3]);
       }
 
     using MedianType = itk::MedianImageFilter<ImageType, ImageType>;


### PR DESCRIPTION
The `ato[if]` functions do not provide mechanisms for distinguishing
between `0` and the error condition where the input can not be converted.

`std::sto[id]` provides exception handling and detects when an invalid
string attempts to be converted to an [integer|double].

`ato[if]()`
 - **Con**: No error handling.
 - **Con**: Handle neither hexadecimal nor octal.

The use of `ato[if]` in code can cause it to be subtly broken.
`ato[if]` makes two very big assumptions indeed:
 - The string represents an integer/floating point value.
 - The integer can fit into an int.

In agreement with:
http://review.source.kitware.com/#/c/23738/