### PR TITLE
COMP: Change to enum to new enum class definitions

### DIFF
--- a/test/itkMorphologicalContourInterpolationTest.cxx
+++ b/test/itkMorphologicalContourInterpolationTest.cxx
@@ -100,7 +100,7 @@ int itkMorphologicalContourInterpolationTest( int argc, char* argv[] )
 
   using ScalarPixelType = itk::ImageIOBase::IOComponentType;
   itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-    inputImageFileName, itk::ImageIOFactory::ReadMode);
+    inputImageFileName, itk::ImageIOFactory::FileModeType::ReadMode);
   if (!imageIO)
     {
     std::cerr << "Could not CreateImageIO for: " << inputImageFileName << std::endl;

--- a/test/itkMorphologicalContourInterpolationTestWithRLEImage.cxx
+++ b/test/itkMorphologicalContourInterpolationTestWithRLEImage.cxx
@@ -114,7 +114,7 @@ int itkMorphologicalContourInterpolationTestWithRLEImage( int argc, char* argv[]
 
   using ScalarPixelType = itk::ImageIOBase::IOComponentType;
   itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-    inputImageFileName, itk::ImageIOFactory::ReadMode);
+    inputImageFileName, itk::ImageIOFactory::FileModeType::ReadMode);
   if (!imageIO)
     {
     std::cerr << "Could not CreateImageIO for: " << inputImageFileName << std::endl;


### PR DESCRIPTION
When ITK is configured with the following:

- ITK_LEGACY_REMOVE = ON

- ITK_FUTURE_LEGACY_REMOVE = ON

- ITK_LEGACY_SILENT = OFF

- Module_MorphologicalContourInt = ON

Build errors occur with references to older 'C' style enums. The following changes incorporate the new enum class: **FileModeType** and resolves such errors.

Co-Authored-By: Hans Johnson hans-johnson@uiowa.edu