### PR TITLE
ENH: Add a flag to enable/disable extrapolation

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "7548a390d71dc25b80e792703ee3cfea17853a99"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "7548a390d71dc25b80e792703ee3cfea17853a99"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "7548a390d71dc25b80e792703ee3cfea17853a99"
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -137,7 +137,7 @@ jobs:
       matrix:
         python-version: [36, 37, 38, 39]
         include:
-          - itk-python-git-tag: "v5.2rc01"
+          - itk-python-git-tag: "v5.2rc03"
 
     steps:
     - uses: actions/checkout@v2
@@ -173,7 +173,7 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.2rc01"
+          - itk-python-git-tag: "v5.2rc03"
 
     steps:
     - uses: actions/checkout@v2
@@ -209,7 +209,7 @@ jobs:
       matrix:
         python-version-minor: [6, 7, 8, 9]
         include:
-          - itk-python-git-tag: "v5.2rc01"
+          - itk-python-git-tag: "v5.2rc03"
 
     steps:
     - name: Get specific version of CMake, Ninja

--- a/include/itkMorphologicalContourInterpolator.h
+++ b/include/itkMorphologicalContourInterpolator.h
@@ -139,6 +139,13 @@ public:
    *   SetLabeledSliceIndices has to be called prior to Update(). */
   itkGetConstMacro( UseCustomSlicePositions, bool );
 
+  /** Perform extrapolation for branch extremities.
+   * Branch extremities are defined as regions having no overlap with any region in the next slice.
+   * Extrapolation helps generate smooth surface closings.
+   *    Default is ON
+   * */
+  itkSetMacro( UseExtrapolation, bool );
+
   /** Use ball instead of default cross structuring element for repeated dilations. */
   void
   SetUseBallStructuringElement( bool useBall )
@@ -223,6 +230,7 @@ protected:
   bool                       m_UseDistanceTransform{ true };
   bool                       m_UseBallStructuringElement{ false };
   bool                       m_UseCustomSlicePositions{ false };
+  bool                       m_UseExtrapolation{ true };
   IdentifierType             m_MinAlignIters; // minimum number of iterations in align method
   IdentifierType             m_MaxAlignIters; // maximum number of iterations in align method
   IdentifierType             m_ThreadCount;   // for thread local instances

--- a/include/itkMorphologicalContourInterpolator.hxx
+++ b/include/itkMorphologicalContourInterpolator.hxx
@@ -1214,12 +1214,18 @@ MorphologicalContourInterpolator< TImage >::InterpolateBetweenTwo( int axis, TIm
     {
       if ( p->second == 0 )
         {
-          Extrapolate( axis, out, label, i, j, iconn, p->first );
+          if ( m_UseExtrapolation )
+            {
+              Extrapolate( axis, out, label, i, j, iconn, p->first );
+            }
           pairs.erase( p++ );
         }
       else if ( p->first == 0 )
         {
-          Extrapolate( axis, out, label, j, i, jconn, p->second );
+          if ( m_UseExtrapolation )
+            {
+              Extrapolate( axis, out, label, j, i, jconn, p->second );
+            }
           pairs.erase( p++ );
         }
       else


### PR DESCRIPTION
This adds a boolean parameter to the filter that lets users disable extrapolations if desired. The flag is `true` by default, so default behavior remains unchanged.

See https://github.com/KitwareMedical/ITKMorphologicalContourInterpolation/issues/85 for context.

Extrapolation enabled:
![DeepinScreenshot_select-area_20210316155419](https://user-images.githubusercontent.com/1732912/111320737-9422e380-8667-11eb-8a2b-981963e80b76.png)


Disabled:
![DeepinScreenshot_select-area_20210316155356](https://user-images.githubusercontent.com/1732912/111320759-9a18c480-8667-11eb-9f15-3851858cb16a.png)
