### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkMorphologicalContourInterpolator.hxx
+++ b/include/itkMorphologicalContourInterpolator.hxx
@@ -26,7 +26,6 @@
 #include "itkImageAlgorithm.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
-#include "itkMorphologicalContourInterpolator.h"
 #include "itkMultiThreaderBase.h"
 #include "itkObjectFactory.h"
 #include "itkOrImageFilter.h"

--- a/include/itkMorphologicalContourInterpolator.hxx
+++ b/include/itkMorphologicalContourInterpolator.hxx
@@ -362,7 +362,7 @@ MorphologicalContourInterpolator< TImage >::FindMedianImageDilations( typename B
     {
       IdentifierType iS = CardinalSymmetricDifference( seq[x], iMask );
       IdentifierType jS = CardinalSymmetricDifference( seq[x], jMask );
-      IdentifierType xScore = iS >= jS ? iS - jS : jS - iS; // abs(iS-jS)
+      IdentifierType xScore = iS >= jS ? iS - jS : jS - iS; // itk::Math::abs(iS-jS)
       if ( xScore < min )
         {
           min = xScore;
@@ -464,9 +464,9 @@ MorphologicalContourInterpolator< TImage >::FindMedianImageDistances( typename B
   long long bestDiff = LLONG_MAX;
   for ( unsigned b = 0; b < maxSize; b++ )
     {
-      long long iS = Math::abs( iTotal - iSum[b] + jSum[b] );
-      long long jS = Math::abs( jTotal - jSum[b] + iSum[b] );
-      long long diff = Math::abs( iS - jS );
+      long long iS = itk::Math::abs( iTotal - iSum[b] + jSum[b] );
+      long long jS = itk::Math::abs( jTotal - jSum[b] + iSum[b] );
+      long long diff = itk::Math::abs( iS - jS );
       if ( diff < bestDiff )
         {
           bestDiff = diff;
@@ -731,7 +731,7 @@ MorphologicalContourInterpolator< TImage >::Interpolate1to1( int axis, TImage* o
     } // iterator destroyed here
 
   // recurse if needed
-  if ( Math::abs( i - j ) > 2 )
+  if ( itk::Math::abs( i - j ) > 2 )
     {
       PixelList regionIDs;
       regionIDs.push_back( 1 );
@@ -739,8 +739,8 @@ MorphologicalContourInterpolator< TImage >::Interpolate1to1( int axis, TImage* o
       int  iReq = i < reqRegion.GetIndex( axis ) ? -1 : ( i > reqRegion.GetIndex( axis ) + IndexValueType( reqRegion.GetSize( axis ) ) ? +1 : 0 );
       int  jReq = j < reqRegion.GetIndex( axis ) ? -1 : ( j > reqRegion.GetIndex( axis ) + IndexValueType( reqRegion.GetSize( axis ) ) ? +1 : 0 );
       int  mReq = mid < reqRegion.GetIndex( axis ) ? -1 : ( mid > reqRegion.GetIndex( axis ) + IndexValueType( reqRegion.GetSize( axis ) ) ? +1 : 0 );
-      bool first = Math::abs( i - mid ) > 1 && Math::abs( iReq + mReq ) <= 1;  // i-mid?
-      bool second = Math::abs( j - mid ) > 1 && Math::abs( jReq + mReq ) <= 1; // j-mid?
+      bool first = itk::Math::abs( i - mid ) > 1 && itk::Math::abs( iReq + mReq ) <= 1;  // i-mid?
+      bool second = itk::Math::abs( j - mid ) > 1 && itk::Math::abs( jReq + mReq ) <= 1; // j-mid?
 
       if ( first )
         {
@@ -1423,7 +1423,7 @@ MorphologicalContourInterpolator< TImage >::InterpolateAlong( int axis, TImage* 
               int jReq = *next < reqRegion.GetIndex( axis ) ? -1 : ( *next > reqRegion.GetIndex( axis ) + IndexValueType( reqRegion.GetSize( axis ) ) ? +1 : 0 );
 
               if ( *prev + 1 < *next                  // only if they are not adjacent slices
-                   && Math::abs( iReq + jReq ) <= 1 ) // and not out of the requested region
+                   && itk::Math::abs( iReq + jReq ) <= 1 ) // and not out of the requested region
                                                       // unless they are on opposite ends
                 {
                   SegmentBetweenTwo< TImage > s;


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

