### PR TITLE
ENH: Bump ITK version and apply http to https reformatting

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "v5.3rc03"
+            itk-git-tag: "d6acfd26bfcdec606d605beb1301bddfb17c05a6"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "v5.3rc03"
+            itk-git-tag: "d6acfd26bfcdec606d605beb1301bddfb17c05a6"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "v5.3rc03"
+            itk-git-tag: "d6acfd26bfcdec606d605beb1301bddfb17c05a6"
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -137,7 +137,7 @@ jobs:
       matrix:
         python-version: [37, 38, 39, 310]
         include:
-          - itk-python-git-tag: "v5.3rc03"
+          - itk-python-git-tag: "v5.3rc04"
 
     steps:
     - uses: actions/checkout@v2
@@ -173,7 +173,7 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.3rc03"
+          - itk-python-git-tag: "v5.3rc04"
 
     steps:
     - uses: actions/checkout@v2
@@ -209,7 +209,7 @@ jobs:
       matrix:
         python-version-minor: [7, 8, 9, 10]
         include:
-          - itk-python-git-tag: "v5.3rc03"
+          - itk-python-git-tag: "v5.3rc04"
 
     steps:
     - name: Get specific version of CMake, Ninja
@@ -242,7 +242,7 @@ jobs:
       run: |
         cd ../../im
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        set PATH="C:\P\grep;%PATH%"
+        set PATH=C:\P\grep;%PATH%
         set CC=cl.exe
         set CXX=cl.exe
         C:\Python3${{ matrix.python-version-minor }}-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py --py-envs "3${{ matrix.python-version-minor }}-x64" --no-cleanup

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ ITKMorphologicalContourInterpolation
 Overview
 --------
 
-An `ITK <http://itk.org>`_-based implementation of morphological contour
+An `ITK <https://itk.org>`_-based implementation of morphological contour
 interpolation based off the paper:
 
   Albu AB1, Beugeling T, Laurendeau D.
@@ -24,13 +24,13 @@ interpolation based off the paper:
   doi: 10.1109/TBME.2008.921158.
 
 Documentation can be found in the `Insight Journal article
-<http://www.insight-journal.org/browse/publication/977>`_::
+<https://www.insight-journal.org/browse/publication/977>`_::
 
   Zukić D., Vicory J., McCormick M., Wisse L., Gerig G., Yushkevich P., Aylward S.
   "ND Morphological Contour Interpolation",
   The Insight Journal. January-December, 2016.
-  http://hdl.handle.net/10380/3563
-  http://insight-journal.org/browse/publication/977
+  https://hdl.handle.net/10380/3563
+  https://insight-journal.org/browse/publication/977
 
 Installation
 ------------

--- a/doc/InsightArticle.cls
+++ b/doc/InsightArticle.cls
@@ -76,11 +76,11 @@
 
 % Define command to make reference to on-line Doxygen documentation
 \newcommand{\doxygen}[1]{
-\href{http://www.itk.org/Doxygen/html/classitk_1_1#1.html}{\code{itk::#1}}}  
+\href{https://www.itk.org/Doxygen/html/classitk_1_1#1.html}{\code{itk::#1}}}  
 
 % Define command to make reference to on-line Doxygen documentation
 \newcommand{\subdoxygen}[2]{
-\href{http://www.itk.org/Doxygen/html/classitk_1_1#1_1_1#2.html}{\code{itk::#1::#2}}}  
+\href{https://www.itk.org/Doxygen/html/classitk_1_1#1_1_1#2.html}{\code{itk::#1::#2}}}  
 
 % Define command for the standard comment introducing classes with similar functionalities
 \newcommand{\relatedClasses}{

--- a/doc/InsightJournal.bib
+++ b/doc/InsightJournal.bib
@@ -35,7 +35,7 @@
 
 @Manual{POVRay,
   Title          = "Persistence of Vision, Ray-Tracer",
-  Address        = "http://www.povray.org",
+  Address        = "https://www.povray.org",
 }
 
 @Book{Romeny1994,
@@ -55,7 +55,7 @@
 @TechReport{Aisemberg,
   Author         = "G.O. Aisemberg",
   Title          = "Vertebrate embryology",
-  Address        = "http://lcw.lehman.edu/lehman/depts/biology/aisemberg/Bio268.html",
+  Address        = "https://lcw.lehman.edu/lehman/depts/biology/aisemberg/Bio268.html",
   Institution    = "Department of Biological Sciences. Lehman College,
                    City University of New York",
   year           = 1998,
@@ -758,7 +758,7 @@
   Title          = "Intrinsic scale for boundary representation of
                    two-dimensional objects",
   Institution    = "MIDAG, University of North Carolina at Chapel Hill",
-  annote         = "http://www.cs.unc.edu/~culver",
+  annote         = "https://www.cs.unc.edu/~culver",
   year           = 1999,
 }
 
@@ -832,7 +832,7 @@
 @Book{Darwin1999,
   Author         = "C. Darwin",
   Title          = "On the Origin of Species",
-  Publisher      = "http://www.gutenberg.org",
+  Publisher      = "https://www.gutenberg.org",
   Edition        = "sixth",
   year           = 1999,
 }
@@ -1796,8 +1796,8 @@
   Title          = {The {ITK} {S}oftware {G}uide},
   Author         = {Ibanez, L. and Schroeder, W. and Ng, L. and Cates, J.},
   Organization   = "Kitware, Inc. ISBN 1-930934-10-6",
-  Address        = {http://www.itk.org/ItkSoftwareGuide.pdf},
-  url            = {http://www.itk.org/ItkSoftwareGuide.pdf},
+  Address        = {https://www.itk.org/ItkSoftwareGuide.pdf},
+  url            = {https://www.itk.org/ItkSoftwareGuide.pdf},
   Publisher      = {Kitware Inc.},
   Edition        = {First},
   year           = 2003,
@@ -1807,8 +1807,8 @@
   Title          = {The {ITK} {S}oftware {G}uide},
   Author         = {Ibanez, L. and Schroeder, W. and Ng, L. and Cates, J.},
   Organization   = "Kitware, Inc. ISBN 1-930934-15-7",
-  Address        = {http://www.itk.org/ItkSoftwareGuide.pdf},
-  url            = {http://www.itk.org/ItkSoftwareGuide.pdf},
+  Address        = {https://www.itk.org/ItkSoftwareGuide.pdf},
+  url            = {https://www.itk.org/ItkSoftwareGuide.pdf},
   Publisher      = {Kitware Inc.},
   Edition        = {Second},
   year           = 2005,
@@ -3469,7 +3469,7 @@
   Title          = "The OpenGL Graphics System: A Specification (Version
                    1.2)",
   Author         = "M. Segal and K. Akeley",
-  Address        = "http://www.opengl.org",
+  Address        = "https://www.opengl.org",
   month          = "march",
   year           = 1998,
 }
@@ -3887,7 +3887,7 @@
   Author         = "J. K. Udupa and S. Samarasekera",
   Title          = "Extraction of fuzzy object information in multidimensional images for quantifying MS lesions of the brain",
   year           = 1998,
-  Institution    = "United States Patent Office http://www.uspto.gov",
+  Institution    = "United States Patent Office https://www.uspto.gov",
   Number         = "5,812,691"
 }
 
@@ -4782,7 +4782,7 @@ Discipline},
   Title          = "The GDCM Library",
   Institution    = "CREATIS (France)",
   Organization   = "CNRS, INSERM, INSA Lyon, UCB Lyon",
-  Address        = "http://www.creatis.insa-lyon.fr/Public/Gdcm/"
+  Address        = "https://www.creatis.insa-lyon.fr/Public/Gdcm/"
 }
 
 @InProceedings{Chung2002,
@@ -4805,7 +4805,7 @@ Discipline},
   Author         = "NEMA",
   Title          = "The DICOM Standard",
   Institution    = "NEMA",
-  Address        = "\url{http://dicom.nema.org/}",
+  Address        = "\url{https://dicom.nema.org/}",
   Publisher      = "National Electical Manufacturers Association",
   Year           = 2014
 }
@@ -4833,7 +4833,7 @@ Discipline},
   Title          = "OpenJPEG",
   Institution    = "Communications and Remote Sensing Laboratory (TELE)",
   Organization   = "Universit\'{e} Catholique de Louvain (UCL), Belgium",
-  Address        = "http://www.openjpeg.org"
+  Address        = "https://www.openjpeg.org"
 }
 
 @TechReport{JPEG2000KeyAdvantages,
@@ -4842,7 +4842,7 @@ Discipline},
   Institution    = "Aware Inc.",
   Year           = 2002,
   Month          = "February",
-  Address        = "http://medical.nema.org/Dicom/minutes/WG-04/2002/2002-02-27/Weisfeiler.doc"
+  Address        = "https://medical.nema.org/Dicom/minutes/WG-04/2002/2002-02-27/Weisfeiler.doc"
 }
 
 @inproceedings{ marcellin00overview,
@@ -4857,7 +4857,7 @@ Discipline},
    author = "Wikipedia",
    title = "{Run-length encoding} --- {W}ikipedia{,} The Free Encyclopedia",
    year = "2016",
-   howpublished = {\url{http://en.wikipedia.org/w/index.php?title=Run-length\%20encoding&oldid=729616046}},
+   howpublished = {\url{https://en.wikipedia.org/w/index.php?title=Run-length\%20encoding&oldid=729616046}},
    note = "[Online; accessed 29-July-2016]"
  }
 
@@ -4880,7 +4880,7 @@ Discipline},
   Author	= "Ga{\"e}tan Lehmann",
   Title		= "Label object representation and manipulation with {ITK}",
 	Journal = "Insight Journal",
-  howpublished		= "\url{http://hdl.handle.net/1926/584}",
+  howpublished		= "\url{https://hdl.handle.net/1926/584}",
   Year		= 2007,
   Month		= 08,
   Language	= en,

--- a/doc/InsightJournal.sty
+++ b/doc/InsightJournal.sty
@@ -1108,11 +1108,11 @@
 %  Commands for adding the link reference to the URL in the Insight Journal
 %
 \newcommand{\urlhandle}[1]{
-\url{http://hdl.handle.net/10380/#1}}  
+\url{https://hdl.handle.net/10380/#1}}  
 
 \newcommand{\IJhandle}[1]{
-Latest version available at the \href{http://www.insight-journal.org}{Insight Journal} [\urlhandle{#1}]\\
-Distributed under \href{http://creativecommons.org/licenses/by/3.0/us/}{Creative Commons Attribution License}}
+Latest version available at the \href{https://www.insight-journal.org}{Insight Journal} [\urlhandle{#1}]\\
+Distributed under \href{https://creativecommons.org/licenses/by/3.0/us/}{Creative Commons Attribution License}}
 
 \newcommand{\IJhandlefooter}[1]{
 \fancyfoot[CO,CE]{

--- a/include/itkMorphologicalContourInterpolator.h
+++ b/include/itkMorphologicalContourInterpolator.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/itkMorphologicalContourInterpolator.hxx
+++ b/include/itkMorphologicalContourInterpolator.hxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
                      'Please refer to:\n'
                      'Zukić Dž., Vicory J., McCormick M., Wisse L., Gerig G., Yushkevich P., Aylward S. '
                      '"nD Morphological Contour Interpolation", '
-                     'Insight Journal, January-December 2016, http://hdl.handle.net/10380/3563.',
+                     'Insight Journal, January-December 2016, https://hdl.handle.net/10380/3563.',
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",

--- a/test/dscComparison.cxx
+++ b/test/dscComparison.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkMorphologicalContourInterpolationTest.cxx
+++ b/test/itkMorphologicalContourInterpolationTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkMorphologicalContourInterpolationTestWithRLEImage.cxx
+++ b/test/itkMorphologicalContourInterpolationTestWithRLEImage.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/manualTest.cxx
+++ b/test/manualTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Automated reformatting with https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/Maintenance/ApplyScriptToRemotes.sh