### PR TITLE
ENH: Bump setup.py and CI to use ITK v5.4 rc2

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -3,7 +3,7 @@ name: Build, test, package
 on: [push,pull_request]
 
 env:
-  itk-git-tag: "v5.3.0"
+  itk-git-tag: "v5.4rc2"
 
 jobs:
   build-test-cxx:
@@ -131,6 +131,6 @@ jobs:
         ctest --output-on-failure -V -S dashboard.cmake
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@b114bdd01a16855f57df0a973e665e61ac83355d
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@3f63de316255a285b0cac4c819d3d45649738999
     secrets:
       pypi_password: ${{ secrets.pypi_password }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.16.3)
 
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 if(CMAKE_CXX_STANDARD EQUAL "11" )
    message(FATAL_ERROR "CMAKE_CXX_STANDARD:STRING=11 is not supported in ITK version 5.3 and greater.")
 endif()
@@ -17,7 +21,7 @@ endif()
 project(MorphologicalContourInterpolation)
 
 if(NOT ITK_SOURCE_DIR)
-  find_package(ITK 4.9 REQUIRED)
+  find_package(ITK REQUIRED)
   list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
   include(ITKModuleExternal)
 else()

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -3,6 +3,7 @@ of manually segmented anatomical contours.
 Enabling testing requires RLEImage module to be enabled.")
 
 itk_module(MorphologicalContourInterpolation
+  ENABLE_SHARED
   DEPENDS
     ITKBinaryMathematicalMorphology
     ITKDistanceMap

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
     keywords='ITK InsightToolkit Segmentation Interpolation-methods',
     url=r'https://github.com/KitwareMedical/ITKMorphologicalContourInterpolation',
     install_requires=[
-        r'itk>=5.3.0'
+        r'itk>=5.4rc2'
     ]
     )


### PR DESCRIPTION
This includes enabling shared libraries in itk-module.cmake and addressing CMake policy CMP0135 and its associated warning.